### PR TITLE
refactor serviceAccount to use create flag with generic annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ iap-helm/
 │   │   ├── _helpers.tpl
 │   │   ├── NOTES.txt
 │   │   ├── statefulset.yaml
+│   │   ├── serviceaccount.yaml
 │   │   ├── service.yaml
 │   │   ├── service-headless.yaml
 │   │   ├── configmap.yaml
@@ -242,7 +243,7 @@ Creates a `StorageClass` when `storageClass.enabled: true`:
 | `resources` | `requests`, `limits` | CPU/memory |
 | `env` | 350+ env vars | MongoDB, Redis, Vault, auth, logging, SNMP |
 | `processExporter` | `enabled`, `image`, `config` | Prometheus sidecar |
-| `serviceAccount` | `name` | Optional SA name |
+| `serviceAccount` | `create`, `name`, `annotations`, `automountServiceAccountToken` | SA creation + cloud IAM federation (IRSA/Workload Identity) |
 | `hostAliases` | list | For Redis Sentinel DNS resolution |
 | `nodeSelector`, `tolerations`, `affinity` | standard k8s scheduling | |
 | `additionalTLSSecrets` | list of `{secretName, mountPath}` | Extra cert mounts |

--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ understand.
 | processExporter.port | int | `9256` | Process exporter metrics port |
 | replicaCount | int | `2` | The number of pods to start |
 | securityContext | object | `{}` | Additional security context |
-| serviceAccount.name | string | `""` | The name of the service account to assign to the StatefulSet pods. When set, the pod will use this service account for RBAC and IAM role bindings (e.g. IRSA on AWS). When left empty, Kubernetes will use the default service account in the namespace. |
+| serviceAccount.create | bool | `false` | When true, the chart creates the ServiceAccount. When false, the pod uses whatever `serviceAccount.name` is set to, or the namespace default SA if empty. |
+| serviceAccount.name | string | `""` | The name of the ServiceAccount to assign to pods. When left empty and `create` is false, Kubernetes uses the namespace default SA. |
+| serviceAccount.annotations | object | `{}` | Annotations added to the ServiceAccount. Used for cloud IAM federation: AWS EKS IRSA (`eks.amazonaws.com/role-arn`), GCP Workload Identity (`iam.gke.io/gcp-service-account`), Azure Workload Identity (`azure.workload.identity/client-id`). |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Controls whether pods automount the SA token. Set to `true` when using IRSA or Workload Identity. |
 | service.name | string | `"iap-service"` | The name of this Kubernetes service object. |
 | service.port | int | `443` | The port that this service object is listening on. |
 | service.type | string | `"ClusterIP"` | The service type. |

--- a/charts/iap/templates/serviceaccount.yaml
+++ b/charts/iap/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "iap.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/iap/templates/serviceaccount.yaml
+++ b/charts/iap/templates/serviceaccount.yaml
@@ -6,9 +6,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "iap.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+    app.kubernetes.io/component: "serviceAccount"
   annotations:
+    kubernetes.io/description: "Itential Automation Platform serviceAccount."
+    {{- include "iap.annotations" . | nindent 4 }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/iap/tests/serviceaccount_test.yaml
+++ b/charts/iap/tests/serviceaccount_test.yaml
@@ -76,8 +76,11 @@ tests:
           value: "Helm"
       - exists:
           path: metadata.labels["helm.sh/chart"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: "serviceAccount"
 
-  - it: should not include annotations block when annotations is empty
+  - it: should always include standard annotations even when no user annotations are set
     set:
       serviceAccount:
         create: true
@@ -85,8 +88,15 @@ tests:
         annotations: {}
         automountServiceAccountToken: false
     asserts:
-      - notExists:
-          path: metadata.annotations
+      - equal:
+          path: metadata.annotations["kubernetes.io/description"]
+          value: "Itential Automation Platform serviceAccount."
+      - exists:
+          path: metadata.annotations["itential.com/copyright"]
+      - exists:
+          path: metadata.annotations["itential.com/license"]
+      - exists:
+          path: metadata.annotations["helm.sh/template-file"]
 
   - it: should set automountServiceAccountToken to false
     set:

--- a/charts/iap/tests/serviceaccount_test.yaml
+++ b/charts/iap/tests/serviceaccount_test.yaml
@@ -1,0 +1,169 @@
+suite: test serviceaccount template
+templates:
+  - serviceaccount.yaml
+values:
+  - ../tests/test-values.yaml
+tests:
+  - it: should not render when create is false
+    set:
+      serviceAccount:
+        create: false
+        name: "iap-serviceaccount"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render when create is omitted (default false)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render ServiceAccount when create is true
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations: {}
+        automountServiceAccountToken: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - isAPIVersion:
+          of: v1
+
+  - it: should set the correct name
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations: {}
+        automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "iap-serviceaccount"
+
+  - it: should set the correct namespace
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations: {}
+        automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: "NAMESPACE"
+
+  - it: should include standard iap labels
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations: {}
+        automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: "iap"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: "RELEASE-NAME"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: "Helm"
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should not include annotations block when annotations is empty
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations: {}
+        automountServiceAccountToken: false
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should set automountServiceAccountToken to false
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations: {}
+        automountServiceAccountToken: false
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should set automountServiceAccountToken to true
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations: {}
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
+
+  - it: should render AWS EKS IRSA annotation
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations:
+          eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/IAP-ElastiCache-Role"
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789012:role/IAP-ElastiCache-Role"
+
+  - it: should render GCP GKE Workload Identity annotation
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations:
+          iam.gke.io/gcp-service-account: "iap@my-project.iam.gserviceaccount.com"
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: metadata.annotations["iam.gke.io/gcp-service-account"]
+          value: "iap@my-project.iam.gserviceaccount.com"
+
+  - it: should render Azure AKS Workload Identity annotation
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations:
+          azure.workload.identity/client-id: "00000000-0000-0000-0000-000000000000"
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: metadata.annotations["azure.workload.identity/client-id"]
+          value: "00000000-0000-0000-0000-000000000000"
+
+  - it: should render multiple annotations
+    set:
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations:
+          eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/IAP-ElastiCache-Role"
+          custom.annotation/key: "some-value"
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::123456789012:role/IAP-ElastiCache-Role"
+      - equal:
+          path: metadata.annotations["custom.annotation/key"]
+          value: "some-value"

--- a/charts/iap/tests/statefulset_test.yaml
+++ b/charts/iap/tests/statefulset_test.yaml
@@ -1083,6 +1083,35 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: "my-service-account"
 
+  - it: should set serviceAccountName when create is true with a named account
+    set:
+      statefulset.enabled: true
+      replicaCount: 1
+      image:
+        repository: "test/app"
+        tag: "v1.0.0"
+        pullPolicy: "IfNotPresent"
+      service:
+        port: 80
+      applicationPort: 8080
+      useTLS: false
+      podSecurityContext: {}
+      securityContext: {}
+      persistentVolumeClaims:
+        enabled: false
+      processExporter:
+        enabled: false
+      serviceAccount:
+        create: true
+        name: "iap-serviceaccount"
+        annotations:
+          eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/IAP-ElastiCache-Role"
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: "iap-serviceaccount"
+
   # Additional TLS Secrets Integration Tests
   - it: should handle additionalTLSSecrets in StatefulSet
     set:

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -98,10 +98,21 @@ image:
 imagePullSecrets: []
 
 serviceAccount:
+  # -- When true, the chart creates the ServiceAccount. When false, the pod uses whatever name is set
+  # -- (or the namespace default SA if name is empty). Set to false for environments that manage SAs externally.
+  create: false
   # -- The name of the service account to assign to the StatefulSet pods.
-  # -- When set, the pod will use this service account for RBAC and IAM role bindings (e.g. IRSA on AWS).
-  # -- When left empty, Kubernetes will use the default service account in the namespace.
+  # -- When set, the pod will use this service account for RBAC and IAM role bindings (e.g. IRSA on AWS EKS,
+  # -- Workload Identity on GKE, Workload Identity on AKS). When left empty, Kubernetes will use the
+  # -- default service account in the namespace.
   name: ""
+  # -- Annotations to add to the ServiceAccount. Used for cloud IAM federation:
+  # -- AWS EKS IRSA:  eks.amazonaws.com/role-arn: "arn:aws:iam::<account>:role/<role>"
+  # -- GCP GKE:       iam.gke.io/gcp-service-account: "<sa>@<project>.iam.gserviceaccount.com"
+  # -- Azure AKS:     azure.workload.identity/client-id: "<client-id>"
+  annotations: {}
+  # -- Controls whether the pod automounts the SA token. Set to true when using IRSA or Workload Identity.
+  automountServiceAccountToken: false
 
 # The issuer to be used if using cert-manager to generate the TLS certificates
 issuer:


### PR DESCRIPTION
Replaces the old enabled/aws.elasticache approach with a simpler create
flag and a generic annotations map, supporting IRSA, GKE Workload
Identity, and AKS without cloud-specific fields baked into the chart.
Adds a full serviceaccount_test.yaml suite and SA test cases in
statefulset_test.yaml. Updates README and CLAUDE.md to reflect the
new values schema.