### PR TITLE
Fix certificate issuerRef and service port name for TLS

### DIFF
--- a/charts/iap/templates/certificate.yaml
+++ b/charts/iap/templates/certificate.yaml
@@ -18,8 +18,8 @@ spec:
   issuerRef:
     name: {{ .Values.certificate.issuerRef.name }}
     kind: {{ .Values.certificate.issuerRef.kind }}
-    {{- if hasKey (.Values.certificate.issuer) "group" }}
-    group: {{ .Values.certificate.issuer.group }}
+    {{- if hasKey (.Values.certificate.issuerRef) "group" }}
+    group: {{ .Values.certificate.issuerRef.group }}
     {{- end }}
   renewBefore: {{ .Values.certificate.renewBefore }}
   duration: {{ .Values.certificate.duration }}

--- a/charts/iap/templates/service.yaml
+++ b/charts/iap/templates/service.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - name: http
+    - name: {{ if .Values.useTLS }}https{{ else }}http{{ end }}
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.applicationPort }}
       protocol: TCP

--- a/charts/iap/tests/service_test.yaml
+++ b/charts/iap/tests/service_test.yaml
@@ -427,3 +427,17 @@ tests:
       - equal:
           path: spec.ports[1].targetPort
           value: 8080
+
+  - it: should name port https when useTLS is true
+    set:
+      service:
+        name: "tls-service"
+        type: "ClusterIP"
+        port: 443
+      applicationPort: 3443
+      useTLS: true
+      useWebSockets: false
+    asserts:
+      - equal:
+          path: spec.ports[0].name
+          value: "https"

--- a/charts/iap/tests/service_test.yaml
+++ b/charts/iap/tests/service_test.yaml
@@ -4,7 +4,7 @@ templates:
 values:
   - ../tests/test-values.yaml
 tests:
-  - it: should render Service with default configuration
+  - it: should render Service with TLS disabled configuration
     set:
       service:
         name: "test-service"

--- a/charts/iap/tests/service_test.yaml
+++ b/charts/iap/tests/service_test.yaml
@@ -11,6 +11,7 @@ tests:
         type: "ClusterIP"
         port: 80
       applicationPort: 8080
+      useTLS: false
       useWebSockets: false
     asserts:
       - hasDocuments:
@@ -163,6 +164,7 @@ tests:
         type: "ClusterIP"
         port: 80
       applicationPort: 80
+      useTLS: false
       useWebSockets: false
     asserts:
       - equal:
@@ -182,6 +184,7 @@ tests:
         type: "ClusterIP"
         port: 443
       applicationPort: 8443
+      useTLS: false
       useWebSockets: false
     asserts:
       - equal:
@@ -230,6 +233,7 @@ tests:
         type: "ClusterIP"
         port: 9999
       applicationPort: 8888
+      useTLS: false
       useWebSockets: false
     asserts:
       - equal:
@@ -398,6 +402,7 @@ tests:
         type: "ClusterIP"
         port: 443
       applicationPort: 3443
+      useTLS: false
       useWebSockets: true
       websocketPort: 8080
     asserts:

--- a/charts/iap/tests/service_test.yaml
+++ b/charts/iap/tests/service_test.yaml
@@ -177,7 +177,7 @@ tests:
           path: spec.ports[0].name
           value: "http"
 
-  - it: should handle standard HTTPS port
+  - it: should handle standard port 443 with TLS disabled
     set:
       service:
         name: "https-service"

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -139,6 +139,8 @@ certificate:
     name: iap-ca-issuer
     # -- The issuer type
     kind: Issuer
+    # -- The API group of the issuer. Leave empty for built-in cert-manager issuers; set for external issuers (e.g. awspca.cert-manager.io).
+    group: ""
   # -- Specifies how long before the certificate expires that cert-manager should try to renew.
   renewBefore: 48h
   # -- Specifies how long the certificate should be valid for (its lifetime).


### PR DESCRIPTION
- Fix certificate.yaml to reference .Values.certificate.issuerRef (not .issuer) for the group field
- Add group field to certificate.issuerRef in values.yaml for external issuer support
- Make service port name dynamic (https/http) based on useTLS flag