### PR TITLE
Fix naming issue with certificate keystores

### DIFF
--- a/charts/iap/tests/certificate_test.yaml
+++ b/charts/iap/tests/certificate_test.yaml
@@ -343,3 +343,26 @@ tests:
       - equal:
           path: metadata.annotations["foo"]
           value: bar
+
+  - it: should render keystores from values.certificate.keystores
+    set:
+      certificate.enabled: true
+      certificate.issuerRef.name: "test-issuer"
+      certificate.issuerRef.kind: "ClusterIssuer"
+      certificate.commonName: "test.com"
+      certificate.domain: "test.com"
+      certificate.renewBefore: "720h"
+      certificate.duration: "2160h"
+      certificate.keystores:
+        jks:
+          create: true
+          passwordSecretRef:
+            name: jks-password
+            key: password
+    asserts:
+      - equal:
+          path: spec.keystores.jks.create
+          value: true
+      - equal:
+          path: spec.keystores.jks.passwordSecretRef.name
+          value: jks-password

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -173,7 +173,7 @@ certificate:
   # -- Specifies any private key properties
   privateKey: {} # include all required properties, passed to the template as is
   # -- Specifies any key store properties
-  keyStores: {} # include all required properties, passed to the template as is
+  keystores: {} # include all required properties, passed to the template as is
   # -- Specifies any subject fields required
   subject: {} # include all required properties, passed to the template as is
 


### PR DESCRIPTION
Rename the certificate keystores value to match what is in the cert-manager
Add a keystores test case